### PR TITLE
Release: create-deckio v0.3.0 - adding CLI flags --help

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3524,7 +3524,7 @@
       }
     },
     "packages/create-deckio": {
-      "version": "0.2.6",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0"

--- a/packages/create-deckio/__tests__/smoke.test.js
+++ b/packages/create-deckio/__tests__/smoke.test.js
@@ -2,12 +2,31 @@ import { describe, it, expect } from 'vitest'
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { execFileSync } from 'child_process'
 import { tmpdir } from 'os'
-import { join, dirname } from 'path'
+import { join, dirname, basename } from 'path'
 import { fileURLToPath } from 'url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkgRoot = join(__dirname, '..')
 const engineInitScript = join(pkgRoot, '..', 'deck-engine', 'scripts', 'init-project.mjs')
+
+/**
+ * Create a temp directory with a fake npm shim so scaffolder doesn't
+ * actually run npm install during tests.
+ */
+function makeTempWithNpmShim() {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'create-deckio-smoke-'))
+  const binDir = join(tempRoot, 'bin')
+  mkdirSync(binDir, { recursive: true })
+  if (process.platform === 'win32') {
+    writeFileSync(join(binDir, 'npm.cmd'), '@echo off\r\nexit /b 0\r\n')
+  } else {
+    const npmShim = join(binDir, 'npm')
+    writeFileSync(npmShim, '#!/bin/sh\nexit 0\n')
+    chmodSync(npmShim, 0o755)
+  }
+  const PATH = `${binDir}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH || ''}`
+  return { tempRoot, PATH }
+}
 
 describe('create-deckio package', () => {
   it('has a valid package.json with bin entry', async () => {
@@ -83,6 +102,250 @@ describe('create-deckio package', () => {
       const sampleInstructions = readFileSync(join(projectDir, '.github', 'instructions', 'sample-content.instructions.md'), 'utf-8')
       expect(sampleInstructions).toContain('`deck.config.js`')
       expect(sampleInstructions).toContain('`__sample`')
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('create-deckio dot directory (.)', () => {
+  it('scaffolds into current directory when using .', () => {
+    const { tempRoot, PATH } = makeTempWithNpmShim()
+    const projectDir = join(tempRoot, 'my-existing-folder')
+    mkdirSync(projectDir, { recursive: true })
+
+    try {
+      execFileSync(
+        process.execPath,
+        [join(pkgRoot, 'index.mjs'), '.'],
+        {
+          cwd: projectDir,
+          stdio: 'pipe',
+          env: {
+            ...process.env,
+            PATH,
+            DECK_TITLE: 'Existing Folder Deck',
+            DECK_THEME: 'dark',
+          },
+        },
+      )
+
+      expect(existsSync(join(projectDir, 'package.json'))).toBe(true)
+      expect(existsSync(join(projectDir, 'deck.config.js'))).toBe(true)
+      expect(existsSync(join(projectDir, 'src', 'slides', 'CoverSlide.jsx'))).toBe(true)
+
+      // Verify slug is derived from directory name, not '.'
+      const deckConfig = readFileSync(join(projectDir, 'deck.config.js'), 'utf-8')
+      expect(deckConfig).toContain('my-existing-folder')
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('derives slug from directory basename when using .', () => {
+    const { tempRoot, PATH } = makeTempWithNpmShim()
+    const projectDir = join(tempRoot, 'quarterly-review')
+    mkdirSync(projectDir, { recursive: true })
+
+    try {
+      execFileSync(
+        process.execPath,
+        [join(pkgRoot, 'index.mjs'), '.'],
+        {
+          cwd: projectDir,
+          stdio: 'pipe',
+          env: {
+            ...process.env,
+            PATH,
+            DECK_TITLE: 'Quarterly Review',
+            DECK_THEME: 'dark',
+          },
+        },
+      )
+
+      const pkgJson = JSON.parse(readFileSync(join(projectDir, 'package.json'), 'utf-8'))
+      expect(pkgJson.name).toBe('deck-project-quarterly-review')
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('create-deckio CLI flags', () => {
+  it('--help flag shows usage without creating files', () => {
+    const { tempRoot, PATH } = makeTempWithNpmShim()
+
+    try {
+      const output = execFileSync(
+        process.execPath,
+        [join(pkgRoot, 'index.mjs'), '--help'],
+        {
+          cwd: tempRoot,
+          stdio: 'pipe',
+          env: { ...process.env, PATH },
+        },
+      ).toString()
+
+      expect(output).toContain('--title')
+      expect(output).toContain('--subtitle')
+      expect(output).toContain('--icon')
+      expect(output).toContain('--theme')
+      expect(output).toContain('--appearance')
+      expect(output).toContain('--palette')
+      expect(output).toContain('--accent')
+      expect(output).toContain('scaffold in current directory')
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('--title flag overrides DECK_TITLE env var', () => {
+    const { tempRoot, PATH } = makeTempWithNpmShim()
+    const projectName = 'flag-title-test'
+    const projectDir = join(tempRoot, projectName)
+
+    try {
+      execFileSync(
+        process.execPath,
+        [join(pkgRoot, 'index.mjs'), projectName, '--title', 'Flag Title Wins'],
+        {
+          cwd: tempRoot,
+          stdio: 'pipe',
+          env: {
+            ...process.env,
+            PATH,
+            DECK_TITLE: 'Env Title Loses',
+            DECK_THEME: 'dark',
+          },
+        },
+      )
+
+      const deckConfig = readFileSync(join(projectDir, 'deck.config.js'), 'utf-8')
+      expect(deckConfig).toContain('Flag Title Wins')
+      expect(deckConfig).not.toContain('Env Title Loses')
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('--theme shadcn with --palette creates shadcn project', () => {
+    const { tempRoot, PATH } = makeTempWithNpmShim()
+    const projectName = 'flag-shadcn-test'
+    const projectDir = join(tempRoot, projectName)
+
+    try {
+      execFileSync(
+        process.execPath,
+        [join(pkgRoot, 'index.mjs'), projectName, '--theme', 'shadcn', '--palette', 'sunset', '--appearance', 'dark'],
+        {
+          cwd: tempRoot,
+          stdio: 'pipe',
+          env: { ...process.env, PATH },
+        },
+      )
+
+      expect(existsSync(join(projectDir, 'components.json'))).toBe(true)
+      expect(existsSync(join(projectDir, 'jsconfig.json'))).toBe(true)
+      expect(existsSync(join(projectDir, 'src', 'components', 'ui', 'button.jsx'))).toBe(true)
+
+      const deckConfig = readFileSync(join(projectDir, 'deck.config.js'), 'utf-8')
+      expect(deckConfig).toContain("designSystem: 'shadcn'")
+      expect(deckConfig).toContain('sunset')
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('--theme funky-punk creates funky-punk project', () => {
+    const { tempRoot, PATH } = makeTempWithNpmShim()
+    const projectName = 'flag-funky-test'
+    const projectDir = join(tempRoot, projectName)
+
+    try {
+      execFileSync(
+        process.execPath,
+        [join(pkgRoot, 'index.mjs'), projectName, '--theme', 'funky-punk'],
+        {
+          cwd: tempRoot,
+          stdio: 'pipe',
+          env: { ...process.env, PATH },
+        },
+      )
+
+      const deckConfig = readFileSync(join(projectDir, 'deck.config.js'), 'utf-8')
+      expect(deckConfig).toContain('funky-punk')
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('--accent flag sets custom accent color', () => {
+    const { tempRoot, PATH } = makeTempWithNpmShim()
+    const projectName = 'flag-accent-test'
+    const projectDir = join(tempRoot, projectName)
+
+    try {
+      execFileSync(
+        process.execPath,
+        [join(pkgRoot, 'index.mjs'), projectName, '--accent', '#ff5500', '--theme', 'default', '--appearance', 'dark'],
+        {
+          cwd: tempRoot,
+          stdio: 'pipe',
+          env: { ...process.env, PATH },
+        },
+      )
+
+      const deckConfig = readFileSync(join(projectDir, 'deck.config.js'), 'utf-8')
+      expect(deckConfig).toContain('#ff5500')
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects invalid --accent hex format', () => {
+    const { tempRoot, PATH } = makeTempWithNpmShim()
+
+    try {
+      execFileSync(
+        process.execPath,
+        [join(pkgRoot, 'index.mjs'), 'bad-accent', '--accent', 'not-a-hex'],
+        {
+          cwd: tempRoot,
+          stdio: 'pipe',
+          env: { ...process.env, PATH },
+        },
+      )
+      // Should not reach here
+      expect.unreachable('Should have thrown on invalid accent')
+    } catch (err) {
+      expect(err.status).not.toBe(0)
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('flags + dot directory work together', () => {
+    const { tempRoot, PATH } = makeTempWithNpmShim()
+    const projectDir = join(tempRoot, 'combined-test')
+    mkdirSync(projectDir, { recursive: true })
+
+    try {
+      execFileSync(
+        process.execPath,
+        [join(pkgRoot, 'index.mjs'), '.', '--title', 'Combined Test', '--subtitle', 'Flag + Dot', '--theme', 'default', '--appearance', 'light', '--accent', '#10b981'],
+        {
+          cwd: projectDir,
+          stdio: 'pipe',
+          env: { ...process.env, PATH },
+        },
+      )
+
+      expect(existsSync(join(projectDir, 'deck.config.js'))).toBe(true)
+      const deckConfig = readFileSync(join(projectDir, 'deck.config.js'), 'utf-8')
+      expect(deckConfig).toContain('Combined Test')
+      expect(deckConfig).toContain('Flag + Dot')
+      expect(deckConfig).toContain('#10b981')
+      expect(deckConfig).toContain('combined-test')
     } finally {
       rmSync(tempRoot, { recursive: true, force: true })
     }

--- a/packages/create-deckio/index.mjs
+++ b/packages/create-deckio/index.mjs
@@ -7,9 +7,10 @@
  *   npx create-deckio my-talk
  */
 import { mkdirSync, writeFileSync, copyFileSync, existsSync, readdirSync } from 'fs'
-import { join, resolve, dirname } from 'path'
+import { join, resolve, dirname, basename } from 'path'
 import { exec, execSync } from 'child_process'
 import { promisify } from 'util'
+import { parseArgs } from 'node:util'
 import { fileURLToPath } from 'url'
 import * as clack from '@clack/prompts'
 
@@ -518,22 +519,57 @@ gh copilot --yolo
 }
 
 async function main() {
-  const arg = process.argv[2]
+  const { values: flags, positionals } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      title: { type: 'string' },
+      subtitle: { type: 'string' },
+      icon: { type: 'string' },
+      theme: { type: 'string' },
+      appearance: { type: 'string' },
+      palette: { type: 'string' },
+      accent: { type: 'string' },
+      help: { type: 'boolean', short: 'h' },
+    },
+    allowPositionals: true,
+    strict: false,
+  })
 
-  if (!arg || arg === '--help' || arg === '-h') {
+  const arg = positionals[0]
+
+  if (!arg || flags.help) {
     console.log(`
   Usage: npm create deckio <project-name>
+         npx create-deckio .                  (scaffold in current directory)
+
+  Options:
+    --title <string>         Deck title
+    --subtitle <string>      Deck subtitle
+    --icon <string>          Emoji icon (default: 🎴)
+    --theme <name>           default | shadcn | funky-punk
+    --appearance <mode>      dark | light
+    --palette <name>         Aurora palette: ocean | sunset | forest | nebula | arctic | minimal (shadcn only)
+    --accent <#hex>          Accent color hex (default theme only, e.g. #6366f1)
+    -h, --help               Show this help
 
   Examples:
     npm create deckio my-talk
-    npm create deckio quarterly-review
-    npx create-deckio cool-deck
+    npx create-deckio quarterly-review
+    npx create-deckio . --title "My Talk" --theme shadcn --palette ocean
+    npx create-deckio cool-deck --theme funky-punk
 `)
     process.exit(0)
   }
 
-  const slug = slugify(arg)
-  const dir = resolve(slug)
+  // Validate --accent if provided
+  if (flags.accent && !/^#[0-9a-fA-F]{6}$/.test(flags.accent)) {
+    console.error('Error: --accent must be a valid hex color (e.g. #6366f1)')
+    process.exit(1)
+  }
+
+  const isDot = arg === '.'
+  const slug = isDot ? slugify(basename(resolve('.'))) : slugify(arg)
+  const dir = isDot ? resolve('.') : resolve(slug)
 
   // Guard: refuse to scaffold into a non-empty existing directory
   if (existsSync(dir)) {
@@ -565,125 +601,203 @@ async function main() {
     clack.intro('✦ DECKIO — new deck')
     clack.note(`Using @deckio/deck-engine ${engineVersionLabel}`, 'Runtime')
 
-    title = await clack.text({
-      message: 'Title',
-      placeholder: defaultTitle,
-      defaultValue: defaultTitle,
-    })
-    if (clack.isCancel(title)) { clack.cancel('Cancelled.'); process.exit(0) }
-
-    subtitle = await clack.text({
-      message: 'Subtitle',
-      placeholder: 'A presentation built with deck-engine',
-      defaultValue: 'A presentation built with deck-engine',
-    })
-    if (clack.isCancel(subtitle)) { clack.cancel('Cancelled.'); process.exit(0) }
-
-    icon = await clack.text({
-      message: 'Icon',
-      placeholder: '🎴',
-      defaultValue: '🎴',
-      hint: 'an emoji for your deck',
-    })
-    if (clack.isCancel(icon)) { clack.cancel('Cancelled.'); process.exit(0) }
-
-    // Choose theme
-    const chosenDesignSystem = await clack.select({
-      message: 'Choose a theme',
-      options: [
-        { value: 'default', label: 'Default', hint: 'CSS custom properties' },
-        { value: 'shadcn', label: 'shadcn/ui', hint: 'Tailwind + shadcn/ui' },
-        { value: 'funky-punk', label: 'Funky Punk 🤘', hint: 'neon pink + lime + chaos' },
-      ],
-      initialValue: 'default',
-    })
-    if (clack.isCancel(chosenDesignSystem)) { clack.cancel('Cancelled.'); process.exit(0) }
-
-    // Map funky-punk directly — skip appearance picker
-    if (chosenDesignSystem === 'funky-punk') {
-      theme = 'funky-punk'
-      designSystem = 'none'
-      appearance = 'dark'
-    } else {
-      // Choose appearance / theme
-      appearance = await clack.select({
-        message: 'Appearance',
-        options: [
-          { value: 'dark', label: 'Dark', hint: 'midnight' },
-          { value: 'light', label: 'Light', hint: 'bright and airy' },
-        ],
-        initialValue: 'dark',
+    title = flags.title ?? await (async () => {
+      const v = await clack.text({
+        message: 'Title',
+        placeholder: defaultTitle,
+        defaultValue: defaultTitle,
       })
-      if (clack.isCancel(appearance)) { clack.cancel('Cancelled.'); process.exit(0) }
+      if (clack.isCancel(v)) { clack.cancel('Cancelled.'); process.exit(0) }
+      return v
+    })()
 
-      // Map selections to theme + designSystem
-      if (chosenDesignSystem === 'shadcn') {
+    subtitle = flags.subtitle ?? await (async () => {
+      const v = await clack.text({
+        message: 'Subtitle',
+        placeholder: 'A presentation built with deck-engine',
+        defaultValue: 'A presentation built with deck-engine',
+      })
+      if (clack.isCancel(v)) { clack.cancel('Cancelled.'); process.exit(0) }
+      return v
+    })()
+
+    icon = flags.icon ?? await (async () => {
+      const v = await clack.text({
+        message: 'Icon',
+        placeholder: '🎴',
+        defaultValue: '🎴',
+        hint: 'an emoji for your deck',
+      })
+      if (clack.isCancel(v)) { clack.cancel('Cancelled.'); process.exit(0) }
+      return v
+    })()
+
+    // Theme selection — skip if --theme flag provided
+    if (flags.theme) {
+      if (flags.theme === 'funky-punk') {
+        theme = 'funky-punk'
+        designSystem = 'none'
+        appearance = flags.appearance || 'dark'
+      } else if (flags.theme === 'shadcn') {
         theme = 'shadcn'
         designSystem = 'shadcn'
+        appearance = flags.appearance ?? await (async () => {
+          const v = await clack.select({
+            message: 'Appearance',
+            options: [
+              { value: 'dark', label: 'Dark', hint: 'midnight' },
+              { value: 'light', label: 'Light', hint: 'bright and airy' },
+            ],
+            initialValue: 'dark',
+          })
+          if (clack.isCancel(v)) { clack.cancel('Cancelled.'); process.exit(0) }
+          return v
+        })()
       } else {
-        theme = appearance // 'dark' or 'light'
+        // default theme
+        appearance = flags.appearance ?? await (async () => {
+          const v = await clack.select({
+            message: 'Appearance',
+            options: [
+              { value: 'dark', label: 'Dark', hint: 'midnight' },
+              { value: 'light', label: 'Light', hint: 'bright and airy' },
+            ],
+            initialValue: 'dark',
+          })
+          if (clack.isCancel(v)) { clack.cancel('Cancelled.'); process.exit(0) }
+          return v
+        })()
+        theme = appearance
         designSystem = 'none'
+      }
+    } else {
+      // Fully interactive theme selection
+      const chosenDesignSystem = await clack.select({
+        message: 'Choose a theme',
+        options: [
+          { value: 'default', label: 'Default', hint: 'CSS custom properties' },
+          { value: 'shadcn', label: 'shadcn/ui', hint: 'Tailwind + shadcn/ui' },
+          { value: 'funky-punk', label: 'Funky Punk 🤘', hint: 'neon pink + lime + chaos' },
+        ],
+        initialValue: 'default',
+      })
+      if (clack.isCancel(chosenDesignSystem)) { clack.cancel('Cancelled.'); process.exit(0) }
+
+      // Map funky-punk directly — skip appearance picker
+      if (chosenDesignSystem === 'funky-punk') {
+        theme = 'funky-punk'
+        designSystem = 'none'
+        appearance = 'dark'
+      } else {
+        // Choose appearance / theme
+        appearance = flags.appearance ?? await (async () => {
+          const v = await clack.select({
+            message: 'Appearance',
+            options: [
+              { value: 'dark', label: 'Dark', hint: 'midnight' },
+              { value: 'light', label: 'Light', hint: 'bright and airy' },
+            ],
+            initialValue: 'dark',
+          })
+          if (clack.isCancel(v)) { clack.cancel('Cancelled.'); process.exit(0) }
+          return v
+        })()
+
+        // Map selections to theme + designSystem
+        if (chosenDesignSystem === 'shadcn') {
+          theme = 'shadcn'
+          designSystem = 'shadcn'
+        } else {
+          theme = appearance // 'dark' or 'light'
+          designSystem = 'none'
+        }
       }
     }
 
     // Color selection depends on design system
     if (designSystem === 'shadcn') {
-      // Aurora palette picker — the palette IS the color identity for shadcn
-      const paletteOptions = AURORA_PALETTES.map((p) => ({
-        value: p.value,
-        label: `${swatch(p.colors[0])}${swatch(p.colors[1])}${swatch(p.colors[2])} ${p.label}`,
-        hint: p.hint,
-      }))
+      if (flags.palette) {
+        const palette = AURORA_PALETTES.find((p) => p.value === flags.palette) || AURORA_PALETTES[0]
+        aurora = { palette: palette.value, colors: palette.colors }
+        accent = auroraAccent(palette.value)
+      } else {
+        // Aurora palette picker — the palette IS the color identity for shadcn
+        const paletteOptions = AURORA_PALETTES.map((p) => ({
+          value: p.value,
+          label: `${swatch(p.colors[0])}${swatch(p.colors[1])}${swatch(p.colors[2])} ${p.label}`,
+          hint: p.hint,
+        }))
 
-      const chosenPalette = await clack.select({
-        message: 'Aurora palette',
-        options: paletteOptions,
-        initialValue: 'ocean',
-      })
-      if (clack.isCancel(chosenPalette)) { clack.cancel('Cancelled.'); process.exit(0) }
+        const chosenPalette = await clack.select({
+          message: 'Aurora palette',
+          options: paletteOptions,
+          initialValue: 'ocean',
+        })
+        if (clack.isCancel(chosenPalette)) { clack.cancel('Cancelled.'); process.exit(0) }
 
-      const palette = AURORA_PALETTES.find((p) => p.value === chosenPalette)
-      aurora = { palette: palette.value, colors: palette.colors }
-      // Derive accent from palette — no separate accent prompt
-      accent = auroraAccent(palette.value)
+        const palette = AURORA_PALETTES.find((p) => p.value === chosenPalette)
+        aurora = { palette: palette.value, colors: palette.colors }
+        // Derive accent from palette — no separate accent prompt
+        accent = auroraAccent(palette.value)
+      }
     } else {
-      // Default design system — accent color preset picker
-      const colorOptions = [
-        ...COLOR_PRESETS.map((c) => ({
-          value: c.value,
-          label: `${swatch(c.value)} ${c.label}`,
-          hint: c.value,
-        })),
-        { value: '__custom', label: '✎ Custom hex', hint: 'enter your own' },
-      ]
+      if (flags.accent) {
+        accent = flags.accent
+      } else {
+        // Default design system — accent color preset picker
+        const colorOptions = [
+          ...COLOR_PRESETS.map((c) => ({
+            value: c.value,
+            label: `${swatch(c.value)} ${c.label}`,
+            hint: c.value,
+          })),
+          { value: '__custom', label: '✎ Custom hex', hint: 'enter your own' },
+        ]
 
-      accent = await clack.select({
-        message: 'Accent color',
-        options: colorOptions,
-        initialValue: '#6366f1',
-      })
-      if (clack.isCancel(accent)) { clack.cancel('Cancelled.'); process.exit(0) }
-
-      if (accent === '__custom') {
-        accent = await clack.text({
-          message: 'Hex color',
-          placeholder: '#6366f1',
-          defaultValue: '#6366f1',
-          validate: (v) => /^#[0-9a-fA-F]{6}$/.test(v) ? undefined : 'Must be a valid hex color (e.g. #6366f1)',
+        accent = await clack.select({
+          message: 'Accent color',
+          options: colorOptions,
+          initialValue: '#6366f1',
         })
         if (clack.isCancel(accent)) { clack.cancel('Cancelled.'); process.exit(0) }
+
+        if (accent === '__custom') {
+          accent = await clack.text({
+            message: 'Hex color',
+            placeholder: '#6366f1',
+            defaultValue: '#6366f1',
+            validate: (v) => /^#[0-9a-fA-F]{6}$/.test(v) ? undefined : 'Must be a valid hex color (e.g. #6366f1)',
+          })
+          if (clack.isCancel(accent)) { clack.cancel('Cancelled.'); process.exit(0) }
+        }
       }
     }
   } else {
-    title = process.env.DECK_TITLE || defaultTitle
-    subtitle = process.env.DECK_SUBTITLE || 'A presentation built with deck-engine'
-    icon = process.env.DECK_ICON || '🎴'
+    title = flags.title || process.env.DECK_TITLE || defaultTitle
+    subtitle = flags.subtitle || process.env.DECK_SUBTITLE || 'A presentation built with deck-engine'
+    icon = flags.icon || process.env.DECK_ICON || '🎴'
 
-    // New env vars: DECK_DESIGN_SYSTEM + DECK_APPEARANCE
+    // Determine design system from --theme flag or env vars
+    const effectiveTheme = flags.theme || null
     const envDesignSystem = process.env.DECK_DESIGN_SYSTEM
     const envAppearance = process.env.DECK_APPEARANCE || 'dark'
 
-    if (envDesignSystem) {
+    if (effectiveTheme) {
+      // --theme flag takes precedence
+      if (effectiveTheme === 'funky-punk') {
+        theme = 'funky-punk'
+        designSystem = 'none'
+        appearance = flags.appearance || 'dark'
+      } else if (effectiveTheme === 'shadcn') {
+        theme = 'shadcn'
+        designSystem = 'shadcn'
+        appearance = flags.appearance || envAppearance
+      } else {
+        appearance = flags.appearance || envAppearance
+        theme = appearance
+        designSystem = 'none'
+      }
+    } else if (envDesignSystem) {
       // New-style env vars
       if (envDesignSystem === 'shadcn') {
         theme = 'shadcn'
@@ -702,14 +816,14 @@ async function main() {
     }
 
     if (designSystem === 'shadcn') {
-      // Aurora palette from env — derive accent from it
-      const envPalette = process.env.DECK_AURORA_PALETTE || 'ocean'
-      const palette = AURORA_PALETTES.find((p) => p.value === envPalette) || AURORA_PALETTES[0]
+      // Aurora palette from flag or env — derive accent from it
+      const paletteName = flags.palette || process.env.DECK_AURORA_PALETTE || 'ocean'
+      const palette = AURORA_PALETTES.find((p) => p.value === paletteName) || AURORA_PALETTES[0]
       aurora = { palette: palette.value, colors: palette.colors }
       accent = auroraAccent(palette.value)
     } else {
-      // Default design system — accent from env
-      accent = process.env.DECK_ACCENT || '#6366f1'
+      // Default design system — accent from flag or env
+      accent = flags.accent || process.env.DECK_ACCENT || '#6366f1'
     }
 
     clack.log.info(`Using @deckio/deck-engine ${engineVersionLabel}`)
@@ -815,9 +929,9 @@ async function main() {
   }
 
   if (installOk) {
-    clack.outro(`✦ Ready! cd ${slug} && npm run dev`)
+    clack.outro(isDot ? '✦ Ready! npm run dev' : `✦ Ready! cd ${slug} && npm run dev`)
   } else {
-    clack.outro(`⚠ cd ${slug} && npm install   (then npm run dev)`)
+    clack.outro(isDot ? '⚠ npm install   (then npm run dev)' : `⚠ cd ${slug} && npm install   (then npm run dev)`)
   }
 }
 

--- a/packages/create-deckio/package.json
+++ b/packages/create-deckio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-deckio",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "Scaffold a new deck presentation project powered by @deckio/deck-engine",
   "type": "module",
   "bin": {

--- a/releases/create-deck-project/v0.3.0.md
+++ b/releases/create-deck-project/v0.3.0.md
@@ -1,0 +1,38 @@
+# create-deckio v0.3.0
+
+**Released:** 2026-03-26
+
+## What changed
+
+### Added
+- Support `.` as project argument — `npx create-deckio .` scaffolds into the current directory, deriving the slug from the folder name
+- CLI flags for all interactive prompts: `--title`, `--subtitle`, `--icon`, `--theme`, `--appearance`, `--palette`, `--accent`
+- Partial flag support — supply some flags and get prompted for the rest
+- `--accent` validation rejects invalid hex colors early
+- Updated `--help` output documenting all flags and the `.` syntax
+
+### Changed
+- Argument parsing now uses Node's built-in `util.parseArgs` (zero new dependencies)
+- Precedence chain: CLI flags > environment variables > interactive prompts > defaults
+- Outro message skips `cd <slug>` when `.` was used
+
+## Upgrade guide
+
+No breaking changes. Existing usage (`npx create-deckio my-talk`) and environment variable support (`DECK_TITLE`, `DECK_THEME`, etc.) continue to work unchanged. The new flags are additive.
+
+**New usage examples:**
+
+```bash
+# Scaffold in current directory
+npx create-deckio .
+
+# Fully non-interactive with flags
+npx create-deckio my-talk --title "My Talk" --theme shadcn --palette ocean --appearance dark
+
+# Partial flags — prompts for remaining options
+npx create-deckio . --theme funky-punk
+```
+
+## Contributors
+
+- GitHub Copilot


### PR DESCRIPTION
Add support for scaffolding into the current directory with `.\ and CLI flags (--title, --subtitle, --icon, --theme, --appearance, --palette, --accent) to bypass interactive prompts.

- Use `npx create-deckio .` to scaffold in cwd
- Flags override env vars; partial flags prompt for the rest
- Node built-in util.parseArgs — zero new dependencies
- 9 new smoke tests (291 total, all passing)
- Bump version 0.2.6 → 0.3.0 (minor — new CLI features)