### PR TITLE
fix(create-deckio): ship security-aware .gitignore by default (blocks core-dump leak vector)

### DIFF
--- a/packages/create-deckio/__tests__/gitignore-defaults.test.js
+++ b/packages/create-deckio/__tests__/gitignore-defaults.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { execFileSync } from 'child_process'
+import { tmpdir } from 'os'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const pkgRoot = join(__dirname, '..')
+
+function makeTempWithNpmShim() {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'create-deckio-gitignore-'))
+  const binDir = join(tempRoot, 'bin')
+  mkdirSync(binDir, { recursive: true })
+  if (process.platform === 'win32') {
+    writeFileSync(join(binDir, 'npm.cmd'), '@echo off\r\nexit /b 0\r\n')
+  } else {
+    const npmShim = join(binDir, 'npm')
+    writeFileSync(npmShim, '#!/bin/sh\nexit 0\n')
+    chmodSync(npmShim, 0o755)
+  }
+  const PATH = `${binDir}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH || ''}`
+  return { tempRoot, PATH }
+}
+
+describe('scaffolded .gitignore security defaults', () => {
+  it('includes crash artifacts, env files, and OS noise in the scaffolded .gitignore', () => {
+    const { tempRoot, PATH } = makeTempWithNpmShim()
+    const projectName = 'gitignore-defaults-test'
+    try {
+      execFileSync(
+        process.execPath,
+        [join(pkgRoot, 'index.mjs'), projectName, '--theme', 'midnight', '--no-install'],
+        { cwd: tempRoot, stdio: 'pipe', env: { ...process.env, PATH } },
+      )
+      const gitignore = readFileSync(join(tempRoot, projectName, '.gitignore'), 'utf-8')
+
+      // Original entries still present.
+      expect(gitignore).toMatch(/^node_modules$/m)
+      expect(gitignore).toMatch(/^dist$/m)
+      expect(gitignore).toMatch(/^\.vite$/m)
+
+      // Env files (token-bearing).
+      expect(gitignore).toMatch(/^\.env$/m)
+      expect(gitignore).toMatch(/^\.env\.local$/m)
+
+      // Crash artifacts \u2014 the core-dump leak vector.
+      expect(gitignore).toMatch(/^core$/m)
+      expect(gitignore).toMatch(/^core\.\*$/m)
+      expect(gitignore).toMatch(/^\*\.core$/m)
+      expect(gitignore).toMatch(/^\*\.dmp$/m)
+      expect(gitignore).toMatch(/^\*\.mdmp$/m)
+      expect(gitignore).toMatch(/^\*\.hprof$/m)
+      expect(gitignore).toMatch(/^\*\.heap$/m)
+      expect(gitignore).toMatch(/^\*\.heapsnapshot$/m)
+
+      // OS / editor noise.
+      expect(gitignore).toMatch(/^\.DS_Store$/m)
+      expect(gitignore).toMatch(/^Thumbs\.db$/m)
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  }, 30000)
+})

--- a/packages/create-deckio/index.mjs
+++ b/packages/create-deckio/index.mjs
@@ -919,7 +919,33 @@ async function main() {
   }
   write(dir, 'AGENTS.md', agentsMd())
   write(dir, 'README.md', README(designSystem))
-  write(dir, '.gitignore', 'node_modules\ndist\n.vite\n')
+  write(dir, '.gitignore', [
+    'node_modules',
+    'dist',
+    '.vite',
+    '',
+    '# Environment files (may contain API keys, OAuth tokens)',
+    '.env',
+    '.env.local',
+    '.env.*.local',
+    '',
+    '# Crash artifacts — ELF core dumps and heap snapshots may contain',
+    '# env-var-resident secrets (Copilot/GitHub/Azure tokens) from the',
+    '# crashed process memory. Never commit them.',
+    'core',
+    'core.*',
+    '*.core',
+    '*.dmp',
+    '*.mdmp',
+    '*.hprof',
+    '*.heap',
+    '*.heapsnapshot',
+    '',
+    '# OS / editor noise',
+    '.DS_Store',
+    'Thumbs.db',
+    '',
+  ].join('\n'))
 
   // shadcn-ready authoring files (setup contract, not bundled primitives)
   if (designSystem === 'shadcn') {


### PR DESCRIPTION
## Summary

Replace the scaffolded `.gitignore` (currently just `node_modules / dist / .vite`) with a security-aware default that blocks the leak vectors observed in the 2026-05-21 incident.

## Why

The current 3-line `.gitignore` left every new deck silently vulnerable to committing:

- **Linux core dumps** (`core`, `core.<pid>`, `*.core`) — ELF process memory snapshots that contain env-var-resident OAuth tokens. One live `ghu_` token was extracted from `red-team-deckio:9a913ec:core.274`. Forensic scan of 5 pilot repos turned up **28 such dumps (~1.5 GiB)** in git history.
- **Heap snapshots** (`*.hprof`, `*.heap`, `*.heapsnapshot`) — same risk profile, also embed runtime secrets.
- **Windows minidumps** (`*.dmp`, `*.mdmp`).
- **`.env` / `.env.local` / `.env.*.local`** — the canonical local-secrets path.
- **OS noise** (`.DS_Store`, `Thumbs.db`).

Engine is the right layer for this fix: every scaffolded deck inherits it **once**, no runtime patching needed, and works regardless of whether the deck is hosted in workspace.deckio.art, run locally, or initialised outside the launcher entirely.

## Change

`packages/create-deckio/index.mjs:922` — single `write(dir, '.gitignore', ...)` call now emits a categorised, commented list.

## Pairs with

- **deck-launcher#20** — runtime quarantine + idempotent `.gitignore` top-up for already-scaffolded decks (additive, won't conflict with this template).
- **deck-launcher#22** — disable the upstream crasher (`@microsoft/workiq`) that produced 100% of observed dumps.

Together these are three independent layers:

1. **Engine** (this PR) — new decks ship with safe defaults.
2. **Launcher #20** — existing decks get the same patterns appended, plus runtime quarantine catches misnamed/escaped files.
3. **Launcher #22** — kill the actual crash source so no dumps get produced.

## Tests

`packages/create-deckio/__tests__/gitignore-defaults.test.js` — scaffolds a real project via the CLI, asserts every security-relevant entry is present in the resulting `.gitignore`.

Full create-deckio suite: **328/328 passing**.

## Backward compatibility

- Existing decks are not modified by this PR (engine only runs at scaffold time).
- New decks get a longer `.gitignore` with the original 3 entries preserved at the top. No user-visible behavior change in the dev loop.
