### PR TITLE
feat: add Dev Container setup for one-click DECKIO authoring

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+	"name": "DECKIO Presentation",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:4-24-trixie@sha256:21f15d367bfc5ceadabb9989be48029cba1e6bd80da323405232614a267a9c45",
+
+	// Forward Vite dev server and auto-open in Simple Browser for live hot-reload preview
+	"forwardPorts": [5173],
+	"portsAttributes": {
+		"5173": {
+			"label": "DECKIO Presentation",
+			"onAutoForward": "openPreview"
+		}
+	},
+
+	// On first container creation: scaffold DECKIO, install deps, and bootstrap git
+	"postCreateCommand": "bash .devcontainer/setup.sh",
+
+	// On every container start: launch the Vite dev server in the background.
+	// nohup + & backgrounds the process so the postStartCommand returns immediately,
+	// letting VS Code finish "Configuring Dev Container" without blocking.
+	"postStartCommand": "echo '\\n🎴 DECKIO is ready! Run: npm run dev\\n   or use the VS Code task: Terminal → Run Task → Start DECKIO'",
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				// GitHub Copilot — drive the deck with natural language prompts
+				"GitHub.copilot",
+				"GitHub.copilot-chat",
+				// Git essentials for GitOps workflow
+				"eamodio.gitlens",
+				"mhutchie.git-graph",
+				// Code quality
+				"esbenp.prettier-vscode",
+				"dbaeumer.vscode-eslint"
+			],
+			"settings": {
+				"chat.agent.enabled": true,
+				"git.autofetch": true,
+				"git.enableSmartCommit": true,
+				"editor.formatOnSave": true,
+				"editor.defaultFormatter": "esbenp.prettier-vscode"
+			}
+		}
+	}
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# DECKIO project bootstrap — runs once on postCreateCommand.
+# Idempotent: safe to run multiple times; each step is guarded.
+set -euo pipefail
+
+WORKSPACE="$(pwd)"
+
+echo "==> Configuring git safe directory..."
+git config --global --add safe.directory "$WORKSPACE"
+
+# ── Git initialisation ────────────────────────────────────────────────────────
+if [ ! -d ".git" ]; then
+  echo "==> Initialising git repository..."
+  git init -b main
+else
+  echo "==> Git repository already initialised, skipping."
+fi
+
+# ── DECKIO scaffolding ────────────────────────────────────────────────────────
+# Only scaffold when no DECKIO project is present yet (no deck-engine dependency).
+if ! grep -q "deck-engine" package.json 2>/dev/null; then
+  if [ "${DECKIO_INTERACTIVE:-}" = "true" ] || ([ "${CODESPACES:-}" != "true" ] && [ -t 0 ]); then
+    echo "==> Scaffolding DECKIO project into current directory..."
+    # `--yes` skips interactive prompts; `.` targets the current directory.
+    npx --yes create-deckio@latest .
+  else
+    echo "==> Non-interactive or Codespaces environment detected, skipping scaffold."
+    echo "    Run the 'Setup DECKIO' task or execute '.devcontainer/setup.sh' manually in the terminal to scaffold the project."
+  fi
+else
+  echo "==> DECKIO project already present, skipping scaffold."
+fi
+
+# ── Node dependencies ─────────────────────────────────────────────────────────
+if [ -f "package.json" ] && [ ! -d "node_modules" ]; then
+  echo "==> Installing npm dependencies..."
+  npm install
+else
+  echo "==> node_modules already present, skipping install."
+fi
+
+# ── Initial git commit ────────────────────────────────────────────────────────
+if ! git log --oneline -1 &>/dev/null; then
+  echo "==> Creating initial commit..."
+  git add -A
+  git commit -m "chore: bootstrap DECKIO presentation project"
+  echo "==> Initial commit created on branch 'main'."
+else
+  echo "==> Git history already exists, skipping initial commit."
+fi
+
+echo ""
+echo "================================================"
+echo "  DECKIO project ready!"
+echo "  Run the 'Start DECKIO' task to start the dev server."
+echo "  Use GitHub Copilot Agent mode to build your deck."
+echo "================================================"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "simpleBrowser.useIntegratedBrowser": true
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,48 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Start DECKIO",
+      "type": "shell",
+      "command": "if [ ! -d node_modules ]; then echo '\\n❌ Project not set up yet. Run: bash .devcontainer/setup.sh\\n' && exit 1; fi && npm run dev -- --host",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "vite",
+        "pattern": {
+          "regexp": "^(.*)$",
+          "message": 1
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "VITE",
+          "endsPattern": "ready in"
+        }
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "group": "dev"
+      }
+    },
+    {
+      "label": "Setup DECKIO",
+      "type": "shell",
+      "command": "bash .devcontainer/setup.sh",
+      "options": {
+        "env": {
+          "DECKIO_INTERACTIVE": "true"
+        }
+      },
+      "group": "none",
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "group": "dev"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds a Dev Container so contributors can author a DECKIO presentation with zero local setup.

On container creation it:
1. Scaffolds a DECKIO project via `create-deckio` (interactive/non-Codespaces only)
2. Installs npm dependencies
3. Creates an initial git commit

It forwards the Vite dev server on port `5173` and opens a live preview in VS Code's Simple Browser. Includes VS Code tasks (**Start DECKIO** / **Setup DECKIO**) referenced by the container.

## Files
- `.devcontainer/devcontainer.json`
- `.devcontainer/setup.sh`
- `.vscode/settings.json`
- `.vscode/tasks.json`

## Notes
No behavioral change to the published packages; this is tooling only.