### PR TITLE
chore: add Renovate configuration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,9 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    ":dependencyDashboard",
+    ":semanticCommits",
+  ],
+}


### PR DESCRIPTION
## What

Adds a Renovate configuration so dependency and GitHub Action updates are automated.

Uses standard hosted presets:
- `config:recommended`
- `helpers:pinGitHubActionDigests` — pins Actions to commit SHAs
- `:dependencyDashboard` — single tracking issue
- `:semanticCommits` — Conventional Commit messages

## Notes
Tooling only; no impact on published packages.